### PR TITLE
Limit nodes in map view to 1300

### DIFF
--- a/frontend/src/components/Map/Map.tsx
+++ b/frontend/src/components/Map/Map.tsx
@@ -63,7 +63,8 @@ export class Map extends React.Component<Map.Props, Map.State> {
   public render() {
     const { appState } = this.props;
     const { filter } = this.state;
-    const nodes = appState.nodes.sorted();
+    let nodes = appState.nodes.sorted();
+    nodes = nodes.length <= 1300 ? nodes : nodes.slice(0, 1300);
 
     return (
       <React.Fragment>


### PR DESCRIPTION
### Ticket
https://github.com/subspace/substrate-telemetry/issues/9

### Summary
The Map view will break when >25k nodes are rendered. This ticket is in preparation for stress testing. This change limits the number of nodes that can be rendered on the Map view to 1300.