### PR TITLE
Show stats view

### DIFF
--- a/frontend/src/components/Chain/Chain.tsx
+++ b/frontend/src/components/Chain/Chain.tsx
@@ -81,23 +81,31 @@ export class Chain extends React.Component<Chain.Props, Chain.State> {
           setDisplay={this.setDisplay}
           hideSettingsNav={this.props.disableNodeViews}
         />
-        {!this.props.disableNodeViews && (
-          <div className="Chain-content-container">
-            <div className="Chain-content">{this.renderContent()}</div>
-          </div>
-        )}
+        <div className="Chain-content-container">
+          <div className="Chain-content">{this.renderContent()}</div>
+        </div>
       </div>
     );
   }
 
   private renderContent() {
     const { display } = this.state;
+    const {
+      appState,
+      appUpdate,
+      connection,
+      pins,
+      sortBy,
+      disableNodeViews,
+    } = this.props;
+
+    if (display === 'stats' || disableNodeViews) {
+      return <Stats appState={appState} />;
+    }
 
     if (display === 'settings') {
       return <Settings settings={this.props.settings} />;
     }
-
-    const { appState, appUpdate, connection, pins, sortBy } = this.props;
 
     if (display === 'list') {
       return (
@@ -112,10 +120,6 @@ export class Chain extends React.Component<Chain.Props, Chain.State> {
 
     if (display === 'map') {
       return <Map appState={appState} />;
-    }
-
-    if (display === 'stats') {
-      return <Stats appState={appState} />;
     }
 
     throw new Error('invalid `display`: ${display}');

--- a/frontend/src/components/Tile.css
+++ b/frontend/src/components/Tile.css
@@ -19,25 +19,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 .Tile {
   font-size: 2.5em;
   text-align: left;
-  width: 260px;
   height: 100px;
   display: inline-block;
   position: relative;
+  padding: 24px 0 0 70px;
+  margin-right: 36px;
 }
 
 .Tile-label {
-  position: absolute;
-  top: 24px;
-  left: 70px;
   right: 0;
   font-size: 0.4em;
   text-transform: uppercase;
 }
 
 .Tile-content {
-  position: absolute;
-  bottom: 16px;
-  left: 70px;
   right: 0;
   font-weight: 300;
   font-size: 0.75em;

--- a/frontend/src/components/Tile.tsx
+++ b/frontend/src/components/Tile.tsx
@@ -30,8 +30,8 @@ export function Tile(props: Tile.Props) {
   return (
     <div className="Tile">
       <Icon src={props.icon} />
-      <span className="Tile-label">{props.title}</span>
-      <span className="Tile-content">{props.children}</span>
+      <div className="Tile-label">{props.title}</div>
+      <div className="Tile-content">{props.children}</div>
     </div>
   );
 }


### PR DESCRIPTION
### Ticket
Closes https://github.com/subspace/substrate-telemetry/issues/14

### Summary
* If `DISABLED_NODES` is true, then only show the Stats view
* Cleans up the header styles so the width of tiles is dynamic

### Screenshot
<img width="1263" alt="Screen Shot 2022-09-02 at 9 03 29 AM" src="https://user-images.githubusercontent.com/4195201/188194605-af7b5d70-4c09-494d-98fa-f1086c29b964.png">
