### PR TITLE
Omit more data related to node

### DIFF
--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -185,12 +185,8 @@ impl InnerLoop {
         denylist: Vec<String>,
         max_queue_len: usize,
         max_third_party_nodes: usize,
+        send_node_data: bool,
     ) -> Self {
-        let send_node_data = !matches!(
-            std::env::var("OMIT_NODE_DATA").as_ref().map(String::as_str),
-            Ok("1" | "true" | "True" | "TRUE")
-        );
-
         InnerLoop {
             node_state: State::new(denylist, max_third_party_nodes),
             node_ids: BiMap::new(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,8 @@ services:
     command: [
       'telemetry_core',
       '--listen', '0.0.0.0:8000',
-      '--max-third-party-nodes', '100000'
+      '--max-third-party-nodes', '100000',
     ]
-    environment:
-      OMIT_NODE_DATA: 0
     ports:
       - 127.0.0.1:8000:8000
     expose:


### PR DESCRIPTION
This pr omits sending addition and removal of nodes to a frontend.

But from a frontend I get a page like this:
![image](https://user-images.githubusercontent.com/22083325/191803602-2efe5631-afd0-4a69-a589-e3c801339eb6.png)

I suspect that frontend is waiting for info about at least one node, while this pr discards sending any node info at all.