### PR TITLE
Add second local shard

### DIFF
--- a/backend/telemetry_shard/src/main.rs
+++ b/backend/telemetry_shard/src/main.rs
@@ -58,7 +58,7 @@ const ABOUT: &str = "This is the Telemetry Backend Shard that forwards the \
 struct Opts {
     /// This is the socket address that this shard is listening to. This is restricted to
     /// localhost (127.0.0.1) by default and should be fine for most use cases. If
-    /// you are using Telemetry in a container, you likely want to set this to '0.0.0.0:8000'
+    /// you are using Telemetry in a container, you likely want to set this to '0.0.0.0:8001'
     #[structopt(short = "l", long = "listen", default_value = "127.0.0.1:8001")]
     socket: std::net::SocketAddr,
     /// The desired log level; one of 'error', 'warn', 'info', 'debug' or 'trace', where

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
       - 127.0.0.1:8080:8080
     expose:
       - 8080
-  telemetry-frontend:
+
+  frontend:
     build:
       dockerfile: Dockerfile
       context: ./frontend/
@@ -31,7 +32,8 @@ services:
       - 127.0.0.1:3000:8000
     expose:
       - 3000
-  telemetry-backend-shard:
+
+  shard0: &shard
     build:
       dockerfile: Dockerfile
       context: ./backend/
@@ -39,14 +41,22 @@ services:
     read_only: true
     command: [
       'telemetry_shard',
-      '--listen', '0.0.0.0:8001',
-      '--core', 'http://telemetry-backend-core:8000/shard_submit'
+      '--listen', '0.0.0.0:80',
+      '--core', 'http://core:8000/shard_submit'
     ]
     ports:
-      - 127.0.0.1:8001:8001
+      - 127.0.0.1:8001:80
     expose:
       - 8001
-  telemetry-backend-core:
+
+  shard1:
+    <<: *shard
+    ports:
+      - 127.0.0.1:8002:80
+    expose:
+      - 8002
+
+  core:
     build:
       dockerfile: Dockerfile
       context: ./backend/


### PR DESCRIPTION
I discovered weird behavior with shard. Memory consumption goes up at some number of nodes, before that it is very low. I believe at some point a single shard can't handle some amount of data (as some components are not parallelized) and we just start to see increase of memory usage (maybe due to increase of some queues).

Let's try having 2 shards and see if it helps