### PR TITLE
Add possibility to have several connections to core from shard

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1671,6 +1671,7 @@ dependencies = [
  "log",
  "num_cpus",
  "primitive-types",
+ "rand",
  "serde",
  "serde_json",
  "simple_logger",

--- a/backend/telemetry_shard/Cargo.toml
+++ b/backend/telemetry_shard/Cargo.toml
@@ -25,6 +25,7 @@ structopt = "0.3.21"
 thiserror = "1.0.25"
 tokio = { version = "1.10.1", features = ["full"] }
 tokio-util = { version = "0.6", features = ["compat"] }
+rand = "0.8"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.3.2"

--- a/backend/telemetry_shard/Cargo.toml
+++ b/backend/telemetry_shard/Cargo.toml
@@ -17,15 +17,15 @@ hyper = "0.14.11"
 log = "0.4.14"
 num_cpus = "1.13.0"
 primitive-types = { version = "0.9.0", features = ["serde"] }
-serde = { version = "1.0.126", features = ["derive"] }
+rand = "0.8"
 serde_json = "1.0.64"
+serde = { version = "1.0.126", features = ["derive"] }
 simple_logger = "1.11.0"
 soketto = "0.6.0"
 structopt = "0.3.21"
 thiserror = "1.0.25"
-tokio = { version = "1.10.1", features = ["full"] }
 tokio-util = { version = "0.6", features = ["compat"] }
-rand = "0.8"
+tokio = { version = "1.10.1", features = ["full"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.3.2"

--- a/backend/telemetry_shard/src/main.rs
+++ b/backend/telemetry_shard/src/main.rs
@@ -24,6 +24,7 @@ mod real_ip;
 use std::{
     collections::HashMap,
     net::IpAddr,
+    num::NonZeroUsize,
     time::{Duration, Instant},
 };
 
@@ -72,6 +73,9 @@ struct Opts {
         default_value = "ws://127.0.0.1:8000/shard_submit/"
     )]
     core_url: Uri,
+    /// Number of aggregators
+    #[structopt(short = "c", long = "core", default_value = "1")]
+    aggregators: NonZeroUsize,
     /// How many different nodes is a given connection to the /submit endpoint allowed to
     /// tell us about before we ignore the rest?
     ///
@@ -138,7 +142,7 @@ fn main() {
 /// Declare our routes and start the server.
 async fn start_server(opts: Opts) -> anyhow::Result<()> {
     let block_list = BlockedAddrs::new(Duration::from_secs(opts.node_block_seconds));
-    let aggregator = Aggregator::spawn(opts.core_url).await?;
+    let aggregator = Aggregator::spawn(opts.core_url, opts.aggregators).await?;
     let socket_addr = opts.socket;
     let max_nodes_per_connection = opts.max_nodes_per_connection;
     let bytes_per_second = opts.max_node_data_per_second;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,13 +49,6 @@ services:
     expose:
       - 8001
 
-  shard1:
-    <<: *shard
-    ports:
-      - 127.0.0.1:8002:80
-    expose:
-      - 8002
-
   core:
     build:
       dockerfile: Dockerfile


### PR DESCRIPTION
The only thing which can be a bottleneck in a shard (like a processing bottleneck) is sending data via shard message aggregator. This pr wraps several ws connection (which are now `AggregatorInternal`) in `Aggregator` structure.