### PR TITLE
Send all changes periodically

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1642,6 +1642,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
+ "itertools",
  "jemallocator",
  "log",
  "maxminddb",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -362,17 +362,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "delegate"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082a24a9967533dc5d743c602157637116fc1b52806d694a5a45e6f32567fcdd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,7 +1636,6 @@ dependencies = [
  "bytes",
  "common",
  "criterion",
- "delegate",
  "fdlimit",
  "flume",
  "futures",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -386,6 +386,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdlimit"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4c9e43643f5a3be4ca5b67d26b98031ff9db6806c3440ae32e02e3ceac3f1b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,6 +1636,7 @@ dependencies = [
  "bytes",
  "common",
  "criterion",
+ "fdlimit",
  "flume",
  "futures",
  "hex",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -362,6 +362,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082a24a9967533dc5d743c602157637116fc1b52806d694a5a45e6f32567fcdd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +1647,7 @@ dependencies = [
  "bytes",
  "common",
  "criterion",
+ "delegate",
  "fdlimit",
  "flume",
  "futures",

--- a/backend/common/src/dense_map.rs
+++ b/backend/common/src/dense_map.rs
@@ -23,6 +23,7 @@
 /// Items are keyed by an Id, which can be any type you wish, but
 /// must be convertible to/from a `usize`. This promotes using a
 /// custom Id type to talk about items in the map.
+#[derive(Clone)]
 pub struct DenseMap<Id, T> {
     /// List of retired indexes that can be re-used
     retired: Vec<usize>,

--- a/backend/common/src/mean_list.rs
+++ b/backend/common/src/mean_list.rs
@@ -17,6 +17,7 @@
 use num_traits::{Float, Zero};
 use std::ops::AddAssign;
 
+#[derive(Clone)]
 pub struct MeanList<T>
 where
     T: Float + AddAssign + Zero + From<u8>,

--- a/backend/common/src/most_seen.rs
+++ b/backend/common/src/most_seen.rs
@@ -19,7 +19,7 @@ use std::hash::Hash;
 
 /// Add items to this, and it will keep track of what the item
 /// seen the most is.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MostSeen<T> {
     current_best: T,
     current_count: usize,

--- a/backend/common/src/node_types.rs
+++ b/backend/common/src/node_types.rs
@@ -78,7 +78,7 @@ impl<'de> Deserialize<'de> for NodeStats {
 }
 
 /// Node IO details.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct NodeIO {
     pub used_state_cache_size: MeanList<f32>,
 }
@@ -112,7 +112,7 @@ impl Block {
 }
 
 /// Node hardware details.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct NodeHardware {
     /// Upload uses means
     pub upload: MeanList<f64>,

--- a/backend/common/src/num_stats.rs
+++ b/backend/common/src/num_stats.rs
@@ -20,6 +20,7 @@ use std::iter::Sum;
 
 /// Keep track of last N numbers pushed onto internal stack.
 /// Provides means to get an average of said numbers.
+#[derive(Clone)]
 pub struct NumStats<T> {
     stack: Box<[T]>,
     index: usize,

--- a/backend/telemetry_core/Cargo.toml
+++ b/backend/telemetry_core/Cargo.toml
@@ -34,6 +34,7 @@ structopt = "0.3.21"
 thiserror = "1.0.25"
 tokio = { version = "1.10.1", features = ["full"] }
 tokio-util = { version = "0.6", features = ["compat"] }
+itertools = "0.10"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.3.2"

--- a/backend/telemetry_core/Cargo.toml
+++ b/backend/telemetry_core/Cargo.toml
@@ -39,6 +39,7 @@ tokio-util = { version = "0.6", features = ["compat"] }
 jemallocator = "0.3.2"
 
 [dev-dependencies]
+fdlimit = "0.2"
 shellwords = "1.1.0"
 test_utils = { path = "../test_utils" }
 criterion = { version = "0.3.4", features = ["async", "async_tokio"] }

--- a/backend/telemetry_core/Cargo.toml
+++ b/backend/telemetry_core/Cargo.toml
@@ -11,7 +11,6 @@ bimap = "0.6.1"
 bincode = "1.3.3"
 bytes = "1.0.1"
 common = { path = "../common" }
-delegate = "0.8.0"
 flume = "0.10.8"
 futures = "0.3.15"
 hex = "0.4.3"

--- a/backend/telemetry_core/Cargo.toml
+++ b/backend/telemetry_core/Cargo.toml
@@ -11,6 +11,7 @@ bimap = "0.6.1"
 bincode = "1.3.3"
 bytes = "1.0.1"
 common = { path = "../common" }
+delegate = "0.8.0"
 flume = "0.10.8"
 futures = "0.3.15"
 hex = "0.4.3"

--- a/backend/telemetry_core/src/aggregator/aggregator.rs
+++ b/backend/telemetry_core/src/aggregator/aggregator.rs
@@ -47,6 +47,8 @@ pub struct AggregatorOpts {
     pub max_third_party_nodes: usize,
     /// Send updates periodically
     pub update_every: Duration,
+    /// Should we send node data?
+    pub send_node_data: bool,
 }
 
 struct AggregatorInternal {
@@ -70,6 +72,7 @@ impl Aggregator {
             max_queue_len,
             max_third_party_nodes,
             update_every,
+            send_node_data,
         }: AggregatorOpts,
     ) -> anyhow::Result<Aggregator> {
         let (tx_to_aggregator, rx_from_external) = flume::unbounded();
@@ -102,6 +105,7 @@ impl Aggregator {
             max_queue_len,
             denylist,
             max_third_party_nodes,
+            send_node_data,
         ));
 
         // Return a handle to our aggregator:
@@ -121,6 +125,7 @@ impl Aggregator {
         max_queue_len: usize,
         denylist: Vec<String>,
         max_third_party_nodes: usize,
+        send_node_data: bool,
     ) where
         A: Sink<(NodeId, IpAddr)> + Send + Unpin + 'static,
     {
@@ -129,6 +134,7 @@ impl Aggregator {
             denylist,
             max_queue_len,
             max_third_party_nodes,
+            send_node_data,
         )
         .handle(rx_from_external.into_stream())
         .await;

--- a/backend/telemetry_core/src/aggregator/aggregator.rs
+++ b/backend/telemetry_core/src/aggregator/aggregator.rs
@@ -15,11 +15,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::inner_loop;
-use crate::find_location::find_location;
-use crate::state::NodeId;
 use common::id_type;
-use futures::{future, Sink, SinkExt};
-use std::net::IpAddr;
+use futures::{Sink, SinkExt};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
@@ -77,14 +74,6 @@ impl Aggregator {
     ) -> anyhow::Result<Aggregator> {
         let (tx_to_aggregator, rx_from_external) = flume::unbounded();
 
-        // Kick off a locator task to locate nodes, which hands back a channel to make location requests
-        let tx_to_locator =
-            find_location(tx_to_aggregator.clone().into_sink().with(|(node_id, msg)| {
-                future::ok::<_, flume::SendError<_>>(inner_loop::ToAggregator::FromFindLocation(
-                    node_id, msg,
-                ))
-            }));
-
         tokio::task::spawn({
             let tx_to_aggregator = tx_to_aggregator.clone();
             let mut timer = tokio::time::interval(update_every);
@@ -101,7 +90,6 @@ impl Aggregator {
         // Handle any incoming messages in our handler loop:
         tokio::spawn(Aggregator::handle_messages(
             rx_from_external,
-            tx_to_locator.into_sink(),
             max_queue_len,
             denylist,
             max_third_party_nodes,
@@ -119,18 +107,14 @@ impl Aggregator {
     /// This is spawned into a separate task and handles any messages coming
     /// in to the aggregator. If nobody is holding the tx side of the channel
     /// any more, this task will gracefully end.
-    async fn handle_messages<A>(
+    async fn handle_messages(
         rx_from_external: flume::Receiver<inner_loop::ToAggregator>,
-        tx_to_aggregator: A,
         max_queue_len: usize,
         denylist: Vec<String>,
         max_third_party_nodes: usize,
         send_node_data: bool,
-    ) where
-        A: Sink<(NodeId, IpAddr)> + Send + Unpin + 'static,
-    {
+    ) {
         inner_loop::InnerLoop::new(
-            tx_to_aggregator,
             denylist,
             max_queue_len,
             max_third_party_nodes,

--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -420,40 +420,6 @@ impl InnerLoop {
                         let _ = feed_channel.send(msg.clone());
                     }
                 }
-                // If many (eg 10k) nodes are connected, serializing all of their info takes time.
-                // So, parallelise this with Rayon, but we still send out messages for each node in order
-                // (which is helpful for the UI as it tries to maintain a sorted list of nodes). The chunk
-                // size is the max number of node info we fit into 1 message; smaller messages allow the UI
-                // to react a little faster and not have to wait for a larger update to come in. A chunk size
-                // of 64 means each message is ~32k.
-                use rayon::prelude::*;
-                let all_feed_messages: Vec<_> = new_chain
-                    .nodes_slice()
-                    .par_iter()
-                    .enumerate()
-                    .chunks(64)
-                    .filter_map(|nodes| {
-                        let mut feed_serializer = FeedMessageSerializer::new();
-                        for (node_id, node) in nodes
-                            .iter()
-                            .filter_map(|&(idx, n)| n.as_ref().map(|n| (idx, n)))
-                        {
-                            feed_serializer.push(feed_message::AddedNode(node_id, node));
-                            feed_serializer.push(feed_message::FinalizedBlock(
-                                node_id,
-                                node.finalized().height,
-                                node.finalized().hash,
-                            ));
-                            if node.stale() {
-                                feed_serializer.push(feed_message::StaleNode(node_id));
-                            }
-                        }
-                        feed_serializer.into_finalized()
-                    })
-                    .collect();
-                for bytes in all_feed_messages {
-                    let _ = feed_channel.send(ToFeedWebsocket::Bytes(bytes));
-                }
 
                 // Actually make a note of the new chain subscription:
                 self.chain_to_feed_conn_ids

--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -258,8 +258,10 @@ impl InnerLoop {
     }
 
     fn send_updates(&mut self) {
-        for (genesis_hash, feed) in self.node_state.drain_chain_updates().collect::<Vec<_>>() {
-            self.finalize_and_broadcast_to_chain_feeds(&genesis_hash, feed);
+        for (genesis_hash, feeds) in self.node_state.drain_chain_updates().collect::<Vec<_>>() {
+            for feed in feeds {
+                self.finalize_and_broadcast_to_chain_feeds(&genesis_hash, feed);
+            }
         }
         let feed_for_all = self.node_state.drain_updates_for_all_feeds();
         self.finalize_and_broadcast_to_all_feeds(feed_for_all);

--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -17,7 +17,7 @@
 use super::aggregator::ConnId;
 use crate::feed_message::{self, FeedMessageSerializer, FeedMessageWriter};
 use crate::find_location;
-use crate::state::{self, NodeId, State};
+use crate::state::{self, BatchedState, NodeId, State};
 use bimap::BiMap;
 use common::node_types::Block;
 use common::{
@@ -156,6 +156,8 @@ pub enum ToFeedWebsocket {
 /// Instances of this are responsible for handling incoming and
 /// outgoing messages in the main aggregator loop.
 pub struct InnerLoop<L> {
+    /// The batched state of our chains and nodes lives here:
+    batched_node_state: BatchedState,
     /// The state of our chains and nodes lives here:
     node_state: State,
     /// We maintain a mapping between NodeId and ConnId+LocalId, so that we know
@@ -187,6 +189,7 @@ impl<L> InnerLoop<L> {
         max_third_party_nodes: usize,
     ) -> Self {
         InnerLoop {
+            batched_node_state: BatchedState::new(denylist.iter().cloned(), max_third_party_nodes),
             node_state: State::new(denylist, max_third_party_nodes),
             node_ids: BiMap::new(),
             feed_channels: HashMap::new(),

--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -184,9 +184,10 @@ impl<L> InnerLoop<L> {
         denylist: Vec<String>,
         max_queue_len: usize,
         max_third_party_nodes: usize,
+        send_node_data: bool,
     ) -> Self {
         InnerLoop {
-            node_state: BatchedState::new(denylist, max_third_party_nodes),
+            node_state: BatchedState::new(denylist, max_third_party_nodes, send_node_data),
             node_ids: BiMap::new(),
             feed_channels: HashMap::new(),
             shard_channels: HashMap::new(),

--- a/backend/telemetry_core/src/aggregator/mod.rs
+++ b/backend/telemetry_core/src/aggregator/mod.rs
@@ -19,7 +19,7 @@ mod aggregator_set;
 mod inner_loop;
 
 // Expose the various message types that can be worked with externally:
-pub use aggregator::AggregatorOpts;
+pub use aggregator::{AggregatorOpts, ConnId};
 pub use inner_loop::{FromFeedWebsocket, FromShardWebsocket, ToFeedWebsocket, ToShardWebsocket};
 
 pub use aggregator_set::*;

--- a/backend/telemetry_core/src/feed_message.rs
+++ b/backend/telemetry_core/src/feed_message.rs
@@ -25,7 +25,7 @@ use common::node_types::{
 };
 use serde_json::to_writer;
 
-type FeedNodeId = usize;
+pub type FeedNodeId = usize;
 
 pub trait FeedMessage {
     const ACTION: u8;

--- a/backend/telemetry_core/src/feed_message.rs
+++ b/backend/telemetry_core/src/feed_message.rs
@@ -63,6 +63,7 @@ impl FeedMessageWriter for DiscardFeedMessages {
     }
 }
 
+#[derive(Clone)]
 pub struct FeedMessageSerializer {
     /// Current buffer,
     buffer: Vec<u8>,
@@ -227,14 +228,14 @@ impl FeedMessageWrite for AddedNode<'_> {
 #[derive(Serialize)]
 pub struct ChainStatsUpdate<'a>(pub &'a ChainStats);
 
-#[derive(Serialize, PartialEq, Eq, Default)]
+#[derive(Serialize, PartialEq, Eq, Default, Clone)]
 pub struct Ranking<K> {
     pub list: Vec<(K, u64)>,
     pub other: u64,
     pub unknown: u64,
 }
 
-#[derive(Serialize, PartialEq, Eq, Default)]
+#[derive(Serialize, PartialEq, Eq, Default, Clone)]
 pub struct ChainStats {
     pub version: Ranking<String>,
 }

--- a/backend/telemetry_core/src/feed_message.rs
+++ b/backend/telemetry_core/src/feed_message.rs
@@ -68,6 +68,12 @@ pub struct FeedMessageSerializer {
     buffer: Vec<u8>,
 }
 
+impl Default for FeedMessageSerializer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 const BUFCAP: usize = 128;
 
 impl FeedMessageSerializer {

--- a/backend/telemetry_core/src/main.rs
+++ b/backend/telemetry_core/src/main.rs
@@ -84,7 +84,7 @@ struct Opts {
     max_third_party_nodes: usize,
     /// Send updates periodically (in seconds).
     #[structopt(long, parse(try_from_str = parse_duration))]
-    update_every: Option<Duration>,
+    update_every: Duration,
 }
 
 fn parse_duration(arg: &str) -> Result<Duration, std::num::ParseIntError> {

--- a/backend/telemetry_core/src/main.rs
+++ b/backend/telemetry_core/src/main.rs
@@ -85,6 +85,9 @@ struct Opts {
     /// Send updates periodically (in seconds).
     #[structopt(long, parse(try_from_str = parse_duration))]
     update_every: Duration,
+    /// Skip sending node data.
+    #[structopt(long)]
+    skip_node_data: bool,
 }
 
 fn parse_duration(arg: &str) -> Result<Duration, std::num::ParseIntError> {
@@ -140,6 +143,7 @@ async fn start_server(
         aggregator_queue_len,
         max_third_party_nodes,
         update_every,
+        skip_node_data,
         ..
     }: Opts,
 ) -> anyhow::Result<()> {
@@ -150,6 +154,7 @@ async fn start_server(
             denylist,
             max_third_party_nodes,
             update_every,
+            send_node_data: !skip_node_data,
         },
     )
     .await?;

--- a/backend/telemetry_core/src/state/batched.rs
+++ b/backend/telemetry_core/src/state/batched.rs
@@ -102,7 +102,7 @@ impl State {
                 *node_count,
             ));
         }
-        for genesis_hash in std::mem::take(&mut self.removed_chains) {
+        for genesis_hash in self.removed_chains.drain() {
             feed.push(feed_message::RemovedChain(genesis_hash))
         }
         feed
@@ -120,10 +120,7 @@ impl State {
             .map(|(genesis_hash, updates)| {
                 let mut vec = vec![];
 
-                for removed_nodes in &std::mem::take(&mut updates.removed_nodes)
-                    .into_iter()
-                    .chunks(Self::MSGS_PER_WS_MSG)
-                {
+                for removed_nodes in &updates.removed_nodes.drain().chunks(Self::MSGS_PER_WS_MSG) {
                     let mut feed = FeedMessageSerializer::new();
                     for removed_node in removed_nodes {
                         feed.push(feed_message::RemovedNode(
@@ -133,10 +130,7 @@ impl State {
                     vec.push(feed);
                 }
 
-                for added_nodes in &std::mem::take(&mut updates.added_nodes)
-                    .into_iter()
-                    .chunks(Self::MSGS_PER_WS_MSG)
-                {
+                for added_nodes in &updates.added_nodes.drain().chunks(Self::MSGS_PER_WS_MSG) {
                     let mut feed = FeedMessageSerializer::new();
                     for (added_node_id, node) in added_nodes {
                         feed.push(feed_message::AddedNode(
@@ -147,10 +141,7 @@ impl State {
                     vec.push(feed);
                 }
 
-                for updated_nodes in &std::mem::take(&mut updates.updated_nodes)
-                    .into_iter()
-                    .chunks(Self::MSGS_PER_WS_MSG)
-                {
+                for updated_nodes in &updates.updated_nodes.drain().chunks(Self::MSGS_PER_WS_MSG) {
                     let mut feed = FeedMessageSerializer::new();
                     for (node_id, updates) in updated_nodes {
                         use node_message::Payload::*;

--- a/backend/telemetry_core/src/state/batched.rs
+++ b/backend/telemetry_core/src/state/batched.rs
@@ -1,0 +1,31 @@
+use crate::feed_message::FeedMessageSerializer;
+
+use super::state::State as OrdinaryState;
+use common::node_types::BlockHash;
+use std::collections::HashMap;
+
+/// Structure with accumulated chain updates
+#[derive(Default)]
+pub struct ChainUpdates {
+    feed: FeedMessageSerializer,
+}
+
+/// Wrapper which batches updates to state.
+pub struct State {
+    // Previous state (which is read only)
+    prev: OrdinaryState,
+    // Next state (which is write only)
+    next: OrdinaryState,
+    /// Accumulated updates for each chain
+    chains: HashMap<BlockHash, ChainUpdates>,
+}
+
+impl State {
+    pub fn new(denylist: impl IntoIterator<Item = String>, max_third_party_nodes: usize) -> Self {
+        Self {
+            prev: OrdinaryState::new([], max_third_party_nodes),
+            next: OrdinaryState::new(denylist, max_third_party_nodes),
+            chains: HashMap::new(),
+        }
+    }
+}

--- a/backend/telemetry_core/src/state/batched.rs
+++ b/backend/telemetry_core/src/state/batched.rs
@@ -1,4 +1,7 @@
-use super::{state::State as OrdinaryState, AddNodeResult, NodeAddedToChain, NodeId, RemovedNode};
+use super::{
+    state::{State as OrdinaryState, StateChain},
+    AddNodeResult, NodeAddedToChain, NodeId, RemovedNode,
+};
 use crate::{
     aggregator::ConnId,
     feed_message::{self, FeedMessageSerializer, FeedMessageWriter},
@@ -39,6 +42,13 @@ pub struct State {
 }
 
 impl State {
+    delegate::delegate! {
+        to self.prev {
+            pub fn iter_chains(&self) -> impl Iterator<Item = StateChain<'_>>;
+            pub fn get_chain_by_genesis_hash(&self, genesis_hash: &BlockHash) -> Option<StateChain<'_>>;
+        }
+    }
+
     pub fn new(denylist: impl IntoIterator<Item = String>, max_third_party_nodes: usize) -> Self {
         Self {
             prev: OrdinaryState::new([], max_third_party_nodes),

--- a/backend/telemetry_core/src/state/batched.rs
+++ b/backend/telemetry_core/src/state/batched.rs
@@ -61,13 +61,6 @@ pub struct State {
 }
 
 impl State {
-    delegate::delegate! {
-        to self.prev {
-            pub fn iter_chains(&self) -> impl Iterator<Item = StateChain<'_>>;
-            pub fn get_chain_by_genesis_hash(&self, genesis_hash: &BlockHash) -> Option<StateChain<'_>>;
-        }
-    }
-
     pub fn new(
         denylist: impl IntoIterator<Item = String>,
         max_third_party_nodes: usize,
@@ -82,6 +75,13 @@ impl State {
             removed_chains: HashSet::new(),
             send_node_data,
         }
+    }
+
+    pub fn iter_chains(&self) -> impl Iterator<Item = StateChain<'_>> {
+        self.prev.iter_chains()
+    }
+    pub fn get_chain_by_genesis_hash(&self, genesis_hash: &BlockHash) -> Option<StateChain<'_>> {
+        self.prev.get_chain_by_genesis_hash(genesis_hash)
     }
 
     /// Drain updates for all feeds and return serializer.

--- a/backend/telemetry_core/src/state/batched.rs
+++ b/backend/telemetry_core/src/state/batched.rs
@@ -1,16 +1,29 @@
-use crate::feed_message::FeedMessageSerializer;
-
-use super::state::State as OrdinaryState;
-use common::node_types::BlockHash;
+use super::{state::State as OrdinaryState, AddNodeResult, NodeAddedToChain, NodeId};
+use crate::{
+    aggregator::ConnId,
+    feed_message::{self, FeedMessageSerializer, FeedMessageWriter},
+};
+use bimap::BiMap;
+use common::{
+    internal_messages::{MuteReason, ShardNodeId},
+    node_types::{BlockHash, NodeDetails},
+};
 use std::collections::HashMap;
 
 /// Structure with accumulated chain updates
-#[derive(Default)]
-pub struct ChainUpdates {
+#[derive(Default, Clone)]
+struct ChainUpdates {
+    /// Chain feed with all its updates
     feed: FeedMessageSerializer,
+    /// Current node count
+    node_count: usize,
+    has_chain_label_changed: bool,
+    /// Current chain label
+    chain_label: Box<str>,
 }
 
 /// Wrapper which batches updates to state.
+#[derive(Clone)]
 pub struct State {
     // Previous state (which is read only)
     prev: OrdinaryState,
@@ -18,6 +31,9 @@ pub struct State {
     next: OrdinaryState,
     /// Accumulated updates for each chain
     chains: HashMap<BlockHash, ChainUpdates>,
+    /// We maintain a mapping between NodeId and ConnId+LocalId, so that we know
+    /// which messages are about which nodes.
+    node_ids: BiMap<NodeId, (ConnId, ShardNodeId)>,
 }
 
 impl State {
@@ -26,6 +42,80 @@ impl State {
             prev: OrdinaryState::new([], max_third_party_nodes),
             next: OrdinaryState::new(denylist, max_third_party_nodes),
             chains: HashMap::new(),
+            node_ids: BiMap::new(),
         }
+    }
+
+    /// Drain updates for all feeds and return serializer.
+    pub fn drain_updates_for_all_feeds(&mut self) -> FeedMessageSerializer {
+        let mut feed = FeedMessageSerializer::new();
+        for (genesis_hash, chain_updates) in &mut self.chains {
+            let ChainUpdates {
+                node_count,
+                has_chain_label_changed,
+                chain_label,
+                ..
+            } = chain_updates;
+
+            if *has_chain_label_changed {
+                feed.push(feed_message::RemovedChain(*genesis_hash));
+                *has_chain_label_changed = false;
+            }
+
+            feed.push(feed_message::AddedChain(
+                chain_label,
+                *genesis_hash,
+                *node_count,
+            ));
+        }
+        feed
+    }
+
+    /// Method which would return updates for each chain with its genesis hash
+    pub fn drain_chain_updates(
+        &'_ mut self,
+    ) -> impl Iterator<Item = (BlockHash, FeedMessageSerializer)> + '_ {
+        self.prev.clone_from(&self.next);
+        self.chains
+            .iter_mut()
+            .map(|(genesis_hash, updates)| (*genesis_hash, std::mem::take(&mut updates.feed)))
+    }
+
+    pub fn add_node(
+        &mut self,
+        genesis_hash: BlockHash,
+        shard_conn_id: ConnId,
+        local_id: ShardNodeId,
+        node: NodeDetails,
+    ) -> Result<NodeId, MuteReason> {
+        let NodeAddedToChain {
+            id: node_id,
+            new_chain_label,
+            node,
+            chain_node_count,
+            has_chain_label_changed,
+            ..
+        } = match self.next.add_node(genesis_hash, node) {
+            AddNodeResult::NodeAddedToChain(details) => details,
+            AddNodeResult::ChainOverQuota => return Err(MuteReason::Overquota),
+            AddNodeResult::ChainOnDenyList => return Err(MuteReason::ChainNotAllowed),
+        };
+
+        // Record ID <-> (shardId,localId) for future messages:
+        self.node_ids.insert(node_id, (shard_conn_id, local_id));
+
+        let updates = self.chains.entry(genesis_hash).or_default();
+
+        // Tell chain subscribers about the node we've just added:
+        updates.feed.push(feed_message::AddedNode(
+            node_id.get_chain_node_id().into(),
+            node,
+        ));
+
+        updates.has_chain_label_changed = has_chain_label_changed;
+        updates.node_count = chain_node_count;
+        updates.chain_label = new_chain_label.to_owned().into_boxed_str();
+
+        Ok(node_id)
     }
 }

--- a/backend/telemetry_core/src/state/batched.rs
+++ b/backend/telemetry_core/src/state/batched.rs
@@ -213,4 +213,23 @@ impl State {
             }
         }
     }
+
+    pub fn update_node_location(&mut self, node_id: NodeId, location: Location) {
+        self.next.update_node_location(node_id, location.clone());
+
+        if let Some(loc) = location {
+            if let Some(chain) = self.next.get_chain_by_node_id(node_id) {
+                self.chains
+                    .entry(chain.genesis_hash())
+                    .or_default()
+                    .feed
+                    .push(feed_message::LocatedNode(
+                        node_id.get_chain_node_id().into(),
+                        loc.latitude,
+                        loc.longitude,
+                        &loc.city,
+                    ));
+            }
+        }
+    }
 }

--- a/backend/telemetry_core/src/state/chain.rs
+++ b/backend/telemetry_core/src/state/chain.rs
@@ -161,7 +161,7 @@ impl Chain {
     pub fn update_node(
         &mut self,
         nid: ChainNodeId,
-        payload: Payload,
+        payload: &Payload,
         feed: &mut impl FeedMessageWriter,
     ) {
         if let Some(block) = payload.best_block() {

--- a/backend/telemetry_core/src/state/chain.rs
+++ b/backend/telemetry_core/src/state/chain.rs
@@ -39,6 +39,7 @@ pub type Label = Box<str>;
 const STALE_TIMEOUT: u64 = 2 * 60 * 1000; // 2 minutes
 const STATS_UPDATE_INTERVAL: Duration = Duration::from_secs(5);
 
+#[derive(Clone)]
 pub struct Chain {
     /// Labels that nodes use for this chain. We keep track of
     /// the most commonly used label as nodes are added/removed.

--- a/backend/telemetry_core/src/state/chain_stats.rs
+++ b/backend/telemetry_core/src/state/chain_stats.rs
@@ -17,7 +17,7 @@
 use super::counter::{Counter, CounterValue};
 use crate::feed_message::ChainStats;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ChainStatsCollator {
     version: Counter<String>,
 }

--- a/backend/telemetry_core/src/state/counter.rs
+++ b/backend/telemetry_core/src/state/counter.rs
@@ -18,7 +18,7 @@ use crate::feed_message::Ranking;
 use std::collections::HashMap;
 
 /// A data structure which counts how many occurences of a given key we've seen.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Counter<K> {
     /// A map containing the number of occurences of a given key.
     ///

--- a/backend/telemetry_core/src/state/mod.rs
+++ b/backend/telemetry_core/src/state/mod.rs
@@ -19,7 +19,9 @@ mod chain_stats;
 mod counter;
 mod node;
 
+mod batched;
 mod state;
 
+pub use batched::State as BatchedState;
 pub use node::Node;
 pub use state::*;

--- a/backend/telemetry_core/src/state/node.rs
+++ b/backend/telemetry_core/src/state/node.rs
@@ -26,6 +26,7 @@ const THROTTLE_THRESHOLD: u64 = 100;
 /// Minimum time of intervals for block updates sent to the browser when throttled, in ms.
 const THROTTLE_INTERVAL: u64 = 1000;
 
+#[derive(Clone)]
 pub struct Node {
     /// Static details
     details: NodeDetails,

--- a/backend/telemetry_core/src/state/state.rs
+++ b/backend/telemetry_core/src/state/state.rs
@@ -41,7 +41,8 @@ impl NodeId {
     }
 }
 
-/// Our state constains node and chain information
+/// Our state contains node and chain information
+#[derive(Clone)]
 pub struct State {
     chains: DenseMap<ChainId, Chain>,
 

--- a/backend/telemetry_core/src/state/state.rs
+++ b/backend/telemetry_core/src/state/state.rs
@@ -217,7 +217,7 @@ impl State {
     pub fn update_node(
         &mut self,
         NodeId(chain_id, chain_node_id): NodeId,
-        payload: Payload,
+        payload: &Payload,
         feed: &mut impl FeedMessageWriter,
     ) {
         let chain = match self.chains.get_mut(chain_id) {
@@ -228,7 +228,7 @@ impl State {
             }
         };
 
-        chain.update_node(chain_node_id, payload, feed)
+        chain.update_node(chain_node_id, &payload, feed)
     }
 
     /// Update the location for a node. Return `false` if the node was not found.

--- a/backend/telemetry_core/tests/e2e_tests.rs
+++ b/backend/telemetry_core/tests/e2e_tests.rs
@@ -60,6 +60,7 @@ fn ghash(id: u64) -> BlockHash {
 /// below) is just to give a feel for _how_ we can test basic feed related things.
 #[tokio::test]
 async fn e2e_feed_sent_version_on_connect() {
+    fdlimit::raise_fd_limit().unwrap();
     let server = start_server_debug().await;
 
     // Connect a feed:
@@ -81,6 +82,7 @@ async fn e2e_feed_sent_version_on_connect() {
 /// with the same message content.
 #[tokio::test]
 async fn e2e_feed_ping_responded_to_with_pong() {
+    fdlimit::raise_fd_limit().unwrap();
     let server = start_server_debug().await;
 
     // Connect a feed:
@@ -106,6 +108,7 @@ async fn e2e_feed_ping_responded_to_with_pong() {
 /// a lot of nodes can simultaneously subscribe and are all sent the expected response.
 #[tokio::test]
 async fn e2e_multiple_feeds_sent_version_on_connect() {
+    fdlimit::raise_fd_limit().unwrap();
     let server = start_server_debug().await;
 
     // Connect a bunch of feeds:
@@ -144,6 +147,7 @@ async fn e2e_multiple_feeds_sent_version_on_connect() {
 /// resulting in a deadlock. This test gives confidence that we don't run into such a deadlock.
 #[tokio::test]
 async fn e2e_lots_of_mute_messages_dont_cause_a_deadlock() {
+    fdlimit::raise_fd_limit().unwrap();
     let mut server = start_server_debug().await;
     let shard_id = server.add_shard().await.unwrap();
 
@@ -200,6 +204,7 @@ async fn e2e_lots_of_mute_messages_dont_cause_a_deadlock() {
 /// If the node is removed, the feed should be told that the chain has gone.
 #[tokio::test]
 async fn e2e_feed_add_and_remove_node() {
+    fdlimit::raise_fd_limit().unwrap();
     // Connect server and add shard
     let mut server = start_server_debug().await;
     let shard_id = server.add_shard().await.unwrap();
@@ -265,6 +270,7 @@ async fn e2e_feed_add_and_remove_node() {
 /// to it by name).
 #[tokio::test]
 async fn e2e_feeds_told_about_chain_rename_and_stay_subscribed() {
+    fdlimit::raise_fd_limit().unwrap();
     // Connect a node:
     let mut server = start_server_debug().await;
     let shard_id = server.add_shard().await.unwrap();
@@ -364,6 +370,7 @@ async fn e2e_feeds_told_about_chain_rename_and_stay_subscribed() {
 /// "removed chain" message only for the node connected to that shard.
 #[tokio::test]
 async fn e2e_feed_add_and_remove_shard() {
+    fdlimit::raise_fd_limit().unwrap();
     let mut server = start_server_debug().await;
 
     let mut shards = vec![];
@@ -443,6 +450,8 @@ async fn e2e_feed_add_and_remove_shard() {
 #[tokio::test]
 async fn e2e_feed_can_subscribe_and_unsubscribe_from_chain() {
     use FeedMessage::*;
+
+    fdlimit::raise_fd_limit().unwrap();
 
     // Start server, add shard, connect node:
     let mut server = start_server_debug().await;
@@ -592,6 +601,8 @@ async fn e2e_node_banned_if_it_sends_too_much_data() {
         node_tx.is_closed()
     }
 
+    fdlimit::raise_fd_limit().unwrap();
+
     assert_eq!(
         try_send_data(1000, 10, 1000).await,
         false,
@@ -608,6 +619,8 @@ async fn e2e_node_banned_if_it_sends_too_much_data() {
 #[tokio::test]
 #[ignore = "Ignored as polkadot is not considered first class chain for telemetry in our fork"]
 async fn e2e_slow_feeds_are_disconnected() {
+    fdlimit::raise_fd_limit().unwrap();
+
     let mut server = start_server(
         ServerOpts::default(),
         // Timeout faster so the test can be quicker:
@@ -708,6 +721,8 @@ async fn e2e_slow_feeds_are_disconnected() {
 /// spamming a load of message IDs and exhausting our memory.
 #[tokio::test]
 async fn e2e_max_nodes_per_connection_is_enforced() {
+    fdlimit::raise_fd_limit().unwrap();
+
     let mut server = start_server(
         ServerOpts::default(),
         CoreOpts::default(),

--- a/backend/test_utils/src/workspace/start_server.rs
+++ b/backend/test_utils/src/workspace/start_server.rs
@@ -37,6 +37,7 @@ pub struct CoreOpts {
     pub feed_timeout: Option<u64>,
     pub worker_threads: Option<usize>,
     pub num_aggregators: Option<usize>,
+    pub update_every: usize,
 }
 
 impl Default for CoreOpts {
@@ -45,6 +46,7 @@ impl Default for CoreOpts {
             feed_timeout: None,
             worker_threads: None,
             num_aggregators: None,
+            update_every: 2,
         }
     }
 }
@@ -161,6 +163,9 @@ pub async fn start_server(
     if let Some(val) = core_opts.num_aggregators {
         core_command = core_command.arg("--num-aggregators").arg(val.to_string());
     }
+    core_command = core_command
+        .arg("--update-every")
+        .arg(core_opts.update_every.to_string());
 
     // Start the server
     Server::start(server::StartOpts::ShardAndCore {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       - /app/tmp:uid=101,gid=101
     environment:
       SUBSTRATE_TELEMETRY_URL: wss://telemetry.subspace.network/feed
-      SUBSPACE_API_URL: http://telemetry.subspace.network/api
-      DISABLE_NODE_LIST: 1
+      SUBSPACE_API_URL: https://telemetry.subspace.network/api
+      DISABLE_NODE_LIST: 0
     ports:
       - 127.0.0.1:3000:8000
     expose:


### PR DESCRIPTION
Fixes #36 

This pr updates telemetry core service in such a way that it sends all the updates within some interval. It does that by having 2 copies of node data. It works as follows:
- sends the old copy to the just connected client
- when we need to push updates to the clients, we take those from feed serializer
- we clone data from the new copy to the old one

If we receive some data from nodes, we just update the new copy and push telemetry messages to the feed serializer.

Some tests right now are failing, but frontend seem to work fine.