### PR TITLE
Fix highest node count by removing one from state

### DIFF
--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -360,11 +360,16 @@ impl InnerLoop {
                 let mut feed_serializer = FeedMessageSerializer::new();
                 feed_serializer.push(feed_message::Version(32));
                 for chain in self.node_state.iter_chains() {
+                    let genesis = chain.genesis_hash();
+                    let highest_node_count = self
+                        .node_state
+                        .get_chain_max_node_count(&chain.genesis_hash())
+                        .expect("Max node count is always present");
                     feed_serializer.push(feed_message::AddedChain(
                         chain.label(),
-                        chain.genesis_hash(),
+                        genesis,
                         chain.node_count(),
-                        chain.highest_node_count(),
+                        highest_node_count,
                     ));
                 }
 

--- a/backend/telemetry_core/src/state/batched.rs
+++ b/backend/telemetry_core/src/state/batched.rs
@@ -153,6 +153,13 @@ impl State {
         self.state.get_chain_by_genesis_hash(genesis_hash)
     }
 
+    pub fn get_chain_max_node_count(&self, genesis_hash: &BlockHash) -> Option<usize> {
+        self.metadata
+            .chains
+            .get(genesis_hash)
+            .map(|meta| meta.highest_node_count)
+    }
+
     /// Drain updates for all feeds and return serializer.
     pub fn drain_updates_for_all_feeds(&mut self) -> FeedMessageSerializer {
         if self.metadata.update(&self.chains) {

--- a/backend/telemetry_core/src/state/chain.rs
+++ b/backend/telemetry_core/src/state/chain.rs
@@ -60,8 +60,6 @@ pub struct Chain {
     genesis_hash: BlockHash,
     /// Maximum number of nodes allowed to connect from this chain
     max_nodes: usize,
-    /// Highest node count on the chain
-    highest_node_count: usize,
     /// Collator for the stats.
     stats_collator: ChainStatsCollator,
     /// Stats for this chain.
@@ -97,7 +95,6 @@ impl Chain {
     pub fn new(genesis_hash: BlockHash, max_nodes: usize) -> Self {
         Chain {
             labels: MostSeen::default(),
-            highest_node_count: 0,
             nodes: DenseMap::new(),
             best: Block::zero(),
             finalized: Block::zero(),
@@ -130,7 +127,6 @@ impl Chain {
         let node_chain_label = &details.chain;
         let label_result = self.labels.insert(node_chain_label);
         let node_id = self.nodes.add(node);
-        self.highest_node_count = self.highest_node_count.max(self.node_count());
 
         AddNodeResult::Added {
             id: node_id,
@@ -353,9 +349,6 @@ impl Chain {
     }
     pub fn node_count(&self) -> usize {
         self.nodes.len()
-    }
-    pub fn highest_node_count(&self) -> usize {
-        self.highest_node_count
     }
     pub fn best_block(&self) -> &Block {
         &self.best

--- a/backend/telemetry_core/src/state/state.rs
+++ b/backend/telemetry_core/src/state/state.rs
@@ -263,9 +263,6 @@ impl<'a> StateChain<'a> {
     pub fn node_count(&self) -> usize {
         self.chain.node_count()
     }
-    pub fn highest_node_count(&self) -> usize {
-        self.chain.highest_node_count()
-    }
     pub fn best_block(&self) -> &'a Block {
         self.chain.best_block()
     }

--- a/backend/telemetry_core/tests/e2e_tests.rs
+++ b/backend/telemetry_core/tests/e2e_tests.rs
@@ -183,7 +183,7 @@ async fn e2e_lots_of_mute_messages_dont_cause_a_deadlock() {
 
     // Wait a little time (just to let everything get deadlocked) before
     // trying to have the aggregator send out feed messages.
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     // Start a feed. If deadlock has happened, it won't receive
     // any messages.


### PR DESCRIPTION
This pr removes one of the two highest node counters from node state, leaving only one in metadata and batched state.