### PR TITLE
Add `implementation` to chain stats page

### DIFF
--- a/backend/telemetry_core/src/feed_message.rs
+++ b/backend/telemetry_core/src/feed_message.rs
@@ -239,6 +239,7 @@ pub struct Ranking<K> {
 #[derive(Serialize, PartialEq, Eq, Default, Clone)]
 pub struct ChainStats {
     pub version: Ranking<String>,
+    pub implementation: Ranking<String>,
     pub target_os: Ranking<String>,
     pub target_arch: Ranking<String>,
     pub cpu: Ranking<String>,

--- a/backend/telemetry_core/src/state/chain_stats.rs
+++ b/backend/telemetry_core/src/state/chain_stats.rs
@@ -102,6 +102,7 @@ fn bucket_memory(memory: u64) -> (u32, Option<u32>) {
 #[derive(Default, Clone)]
 pub struct ChainStatsCollator {
     version: Counter<String>,
+    implementation: Counter<String>,
     target_os: Counter<String>,
     target_arch: Counter<String>,
     cpu: Counter<String>,
@@ -124,6 +125,9 @@ impl ChainStatsCollator {
         op: CounterValue,
     ) {
         self.version.modify(Some(&*details.version), op);
+
+        self.implementation
+            .modify(Some(&*details.implementation), op);
 
         self.target_os
             .modify(details.target_os.as_ref().map(|value| &**value), op);
@@ -206,6 +210,7 @@ impl ChainStatsCollator {
     pub fn generate(&self) -> ChainStats {
         ChainStats {
             version: self.version.generate_ranking_top(10),
+            implementation: self.implementation.generate_ranking_top(10),
             target_os: self.target_os.generate_ranking_top(10),
             target_arch: self.target_arch.generate_ranking_top(10),
             cpu: self.cpu.generate_ranking_top(10),

--- a/frontend/src/common/types.ts
+++ b/frontend/src/common/types.ts
@@ -98,6 +98,7 @@ export type Range = [number, number | null];
 
 export type ChainStats = {
   version: Maybe<Ranking<string>>;
+  implementation: Maybe<Ranking<string>>;
   target_os: Maybe<Ranking<string>>;
   target_arch: Maybe<Ranking<string>>;
   cpu: Maybe<Ranking<string>>;

--- a/frontend/src/components/Stats/Stats.tsx
+++ b/frontend/src/components/Stats/Stats.tsx
@@ -154,6 +154,7 @@ export class Stats extends React.Component<StatsProps> {
     const stats = appState.chainStats;
     if (stats) {
       add('version', 'Version', identity, stats.version);
+      add('implementation', 'Implementation', identity, stats.implementation);
       add('target_os', 'Operating System', identity, stats.target_os);
       add('target_arch', 'CPU Architecture', identity, stats.target_arch);
       add('cpu', 'CPU', identity, stats.cpu);


### PR DESCRIPTION
Currently there is no way to summarize what implementations (subspace-node, space-acres or pulsar) are being run on a network. This PR introduces `implementation` to `ChainStats` and displays the distribution on the network stats page.

![image](https://github.com/subspace/substation/assets/37932802/11be387b-c75b-4844-9f82-5eb82e050c9c)
