### PR TITLE
add `implementation` to `version` on list and stats pages

### DIFF
--- a/backend/telemetry_core/src/state/chain_stats.rs
+++ b/backend/telemetry_core/src/state/chain_stats.rs
@@ -124,7 +124,8 @@ impl ChainStatsCollator {
         hwbench: Option<&common::node_types::NodeHwBench>,
         op: CounterValue,
     ) {
-        self.version.modify(Some(&*details.version), op);
+        let full_version = format!("{} v{}", details.implementation, details.version);
+        self.version.modify(Some(&full_version), op);
 
         self.implementation
             .modify(Some(&*details.implementation), op);

--- a/frontend/src/components/List/Column/ImplementationColumn.tsx
+++ b/frontend/src/components/List/Column/ImplementationColumn.tsx
@@ -104,7 +104,7 @@ export class ImplementationColumn extends React.Component<ColumnProps> {
     return (
       <td className="Column">
         <Tooltip text={`${implementation} v${version}`} />
-        <Icon src={implIcon} /> {semver}
+        <Icon src={implIcon} /> {`${implementation} v${semver}`}
       </td>
     );
   }


### PR DESCRIPTION
On the stats page, aggregate statistics are shown for `Version` but these are without the context of `Implementation` which make the results less intuitive. This PR prepends `Implementation` to `Version` on the stats and list pages.

![image](https://github.com/subspace/substation/assets/37932802/05f94a2a-5bcb-4cde-a603-ce2e5a791e59)
![image](https://github.com/subspace/substation/assets/37932802/99ba1c77-e6b3-45bc-a0f1-70af15490e11)
