### PR TITLE
Fix typo incrementing instead of decrementing

### DIFF
--- a/backend/common/src/most_seen.rs
+++ b/backend/common/src/most_seen.rs
@@ -124,7 +124,7 @@ impl<T: Hash + Eq + Clone> MostSeen<T> {
 
         // Item is in the map; not the best anyway. decrement count.
         if let Some(count) = self.others.get_mut(item) {
-            *count += 1;
+            *count = count.saturating_sub(1);
         }
         ChangeResult::NoChange
     }

--- a/backend/common/src/most_seen.rs
+++ b/backend/common/src/most_seen.rs
@@ -248,5 +248,11 @@ mod test {
         assert!(res.has_changed());
         assert_eq!(a.best_count(), 2);
         assert_eq!(*a.best(), "First"); // First is now ahead
+
+        a.remove(&"Third"); // 0, or 2 with bug #595
+        a.remove(&"Third"); // 0, or 4 with bug #595
+        a.insert(&"Third"); // 1, or 5 with bug #595
+        assert_eq!(a.best_count(), 2);
+        assert_eq!(*a.best(), "First"); // First is still ahead
     }
 }


### PR DESCRIPTION
This PR solves the label (network name) issue in Subspace Telemetry where Taurus testnet is sometimes labeled as Autonomys Mainnet. 

The issue is that for determining the label of the network it's used a voting-like system in which when nodes start sending telemetry logs also send its network information  (genesis hash, network name, etc.). For each genesis hash the network name that has been sent the most times is the one to be shown. 

The issue was that when a node lost connection with telemetry instead of decreasing the number of votes from the network name they voted the service was increasing the number of votes, leading to a corruption of the voting. With the current fix, as long as the number of nodes sending the correct network name remains higher from those sending a wrong name, the correct label should be shown.

That being said this highlights an underlying issue in which some nodes are sending telemetry logs with the wrong network name but the correct genesis hash. I'll be looking for that error but this should solve the issue of wrong network label.